### PR TITLE
fix: disable Yoast primary category picker for sponsor terms

### DIFF
--- a/includes/class-newspack-sponsors-editor.php
+++ b/includes/class-newspack-sponsors-editor.php
@@ -45,7 +45,7 @@ final class Newspack_Sponsors_Editor {
 	 */
 	public function __construct() {
 		add_action( 'the_post', [ __CLASS__, 'strip_editor_modifications' ] );
-		add_filter( 'wpseo_primary_term_taxonomies', [ __CLASS__, 'disable_yoast_category_picker' ] );
+		add_filter( 'wpseo_primary_term_taxonomies', [ __CLASS__, 'disable_yoast_primary_category_picker' ], 10, 2 );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 	}
 
@@ -76,16 +76,23 @@ final class Newspack_Sponsors_Editor {
 	}
 
 	/**
-	 * Disable the Yoast primary category picker for Sponsor posts.
+	 * Disable the Yoast primary category picker for Sponsor posts and terms.
 	 *
-	 * @param array $categories Array of categories.
+	 * @param array  $taxonomies Array of taxonomies.
+	 * @param string $post_type Post type of the current post.
 	 */
-	public static function disable_yoast_category_picker( $categories ) {
-		if ( Core::NEWSPACK_SPONSORS_CPT === get_post_type() ) {
+	public static function disable_yoast_primary_category_picker( $taxonomies, $post_type ) {
+		// Disable for all taxonomies on Sponsor posts.
+		if ( Core::NEWSPACK_SPONSORS_CPT === $post_type ) {
 			return [];
 		}
 
-		return $categories;
+		// Disable for sponsor tax terms everywhere.
+		if ( isset( $taxonomies[ Core::NEWSPACK_SPONSORS_TAX ] ) ) {
+			unset( $taxonomies[ Core::NEWSPACK_SPONSORS_TAX ] );
+		}
+
+		return $taxonomies;
 	}
 
 	/**


### PR DESCRIPTION
We were already disabling this picker for Sponsor posts, but it also needs to be disabled for sponsor tax terms when selecting multiple sponsors on regular posts.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the Yoast primary category dropdown from the sponsor taxonomy sidebar panel. This was previously showing up when assigning more than one sponsor to a post. Closes #11.

<img width="263" alt="Screen Shot 2020-08-05 at 2 25 36 PM" src="https://user-images.githubusercontent.com/2230142/89460459-8eefd480-d727-11ea-8481-8c9545bec143.png">

### How to test the changes in this Pull Request:

1. Make sure you have at least two published sponsors.
2. Edit any post and select more than one sponsor under the Sponsors sidebar panel.
3. Before applying the patch, observe the Primary Category dropdown appear while more than one sponsor is selected.
4. After applying the patch, observe that the Primary Category dropdown does not appear, regardless of how many sponsors are selected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
