### PR TITLE
fix: remove "Add new sponsor" link from sidebar

### DIFF
--- a/includes/class-newspack-sponsors-editor.php
+++ b/includes/class-newspack-sponsors-editor.php
@@ -107,7 +107,7 @@ final class Newspack_Sponsors_Editor {
 	 * Load up JS/CSS for editor.
 	 */
 	public static function enqueue_block_editor_assets() {
-		if ( ! self::is_editing_sponsor() ) {
+		if ( ! self::is_editing_sponsor() && 'post' !== get_post_type() ) {
 			return;
 		}
 

--- a/src/editor/taxonomy-panel/index.js
+++ b/src/editor/taxonomy-panel/index.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -13,23 +14,37 @@ import { Fragment } from '@wordpress/element';
  */
 export const TaxonomyPanel = PostTaxonomies => {
 	return props => {
-		const { slug } = props;
-		const message =
-			'category' === slug
-				? __(
-						'Select one or more post categories to associate this sponsor with those categories.',
-						'newspack-sponsors'
-				  )
-				: __(
-						'Add one or more post tags to associate this sponsor with those tags.',
-						'newspack-sponsors'
-				  );
+		const postType = select( 'core/editor' ).getCurrentPostType();
+
+		if ( 'newspack_spnsrs_cpt' !== postType && 'post' !== postType ) {
+			return <PostTaxonomies { ...props } />;
+		}
+
+		// Remove "Add new sponsors" link since sponsor terms are shadow terms of sponsor posts.
+		if ( 'newspack_spnsrs_tax' === slug ) {
+			props.hasCreateAction = false;
+		}
+
+		const { slug, taxonomy } = props;
+		const { hierarchical, labels } = taxonomy;
+		const message = sprintf(
+			__(
+				// Translators: explanation for applying sponsors to a taxonomy term.
+				'%s one or more post %s to associate this sponsor with those %s.',
+				'newspack-sponsors'
+			),
+			hierarchical ? __( 'Select ', 'newspack-sponsors' ) : __( 'Add ', 'newspack-sponsors' ),
+			labels.name.toLowerCase(),
+			labels.name.toLowerCase()
+		);
 
 		return (
 			<Fragment>
-				<p>
-					<em>{ message }</em>
-				</p>
+				{ 'newspack_spnsrs_cpt' === postType && ( slug === 'category' || slug === 'post_tag' ) && (
+					<p>
+						<em>{ message }</em>
+					</p>
+				) }
 				<PostTaxonomies { ...props } />
 			</Fragment>
 		);

--- a/src/editor/taxonomy-panel/index.js
+++ b/src/editor/taxonomy-panel/index.js
@@ -20,11 +20,6 @@ export const TaxonomyPanel = PostTaxonomies => {
 			return <PostTaxonomies { ...props } />;
 		}
 
-		// Remove "Add new sponsors" link since sponsor terms are shadow terms of sponsor posts.
-		if ( 'newspack_spnsrs_tax' === slug ) {
-			props.hasCreateAction = false;
-		}
-
 		const { slug, taxonomy } = props;
 		const { hierarchical, labels } = taxonomy;
 		const message = sprintf(
@@ -37,6 +32,11 @@ export const TaxonomyPanel = PostTaxonomies => {
 			labels.name.toLowerCase(),
 			labels.name.toLowerCase()
 		);
+
+		// Remove "Add new sponsors" link since sponsor terms are shadow terms of sponsor posts.
+		if ( 'newspack_spnsrs_tax' === slug ) {
+			props.hasCreateAction = false;
+		}
 
 		return (
 			<Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the "Add new sponsor" link from the block editor sidebar panel. Sponsor tax terms are shadow terms of the sponsor post type and should never be created, edited, or deleted independently of the post type.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #16.

### How to test the changes in this Pull Request:

1. Before checking out this branch, edit any post and expand the "Sponsors" sidebar panel. Observe the "Add new sponsor" link beneath the sponsor terms:

<img width="281" alt="Screen Shot 2020-08-18 at 4 54 29 PM" src="https://user-images.githubusercontent.com/2230142/90573363-85c52580-e173-11ea-910c-6a4609c49800.png">

2. Check out this branch and run `npm run build`.

3. Refresh the editor page and expand the Sponsors panel again. Now observe that the link is gone:

<img width="281" alt="Screen Shot 2020-08-18 at 4 54 01 PM" src="https://user-images.githubusercontent.com/2230142/90573399-9d041300-e173-11ea-96ea-ed7693533023.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
