### PR TITLE
feat: settings use value instead of placeholder

### DIFF
--- a/includes/class-newspack-sponsors-settings.php
+++ b/includes/class-newspack-sponsors-settings.php
@@ -78,34 +78,22 @@ final class Newspack_Sponsors_Settings {
 
 		return [
 			[
-				'label'       => __( 'Default Sponsor Byline Prefix', 'newspack-sponsors' ),
-				'placeholder' => sprintf(
-					// Translators: placeholder for default byline value.
-					__( 'Default: “%s”', 'newspack-sponsors' ),
-					$defaults['byline']
-				),
-				'key'         => 'newspack_sponsors_default_byline',
-				'type'        => 'input',
+				'label' => __( 'Default Sponsor Byline Prefix', 'newspack-sponsors' ),
+				'value' => $defaults['byline'],
+				'key'   => 'newspack_sponsors_default_byline',
+				'type'  => 'input',
 			],
 			[
-				'label'       => __( 'Default Sponsored Flag Label', 'newspack-sponsors' ),
-				'placeholder' => sprintf(
-					// Translators: placeholder for default flag value.
-					__( 'Default: “%s”', 'newspack-sponsors' ),
-					$defaults['flag']
-				),
-				'key'         => 'newspack_sponsors_default_flag',
-				'type'        => 'input',
+				'label' => __( 'Default Sponsored Flag Label', 'newspack-sponsors' ),
+				'value' => $defaults['flag'],
+				'key'   => 'newspack_sponsors_default_flag',
+				'type'  => 'input',
 			],
 			[
-				'label'       => __( 'Default Sponsorship Disclaimer', 'newspack-sponsors' ),
-				'placeholder' => sprintf(
-					// Translators: placeholder for default disclaimer value.
-					__( 'Default: “%s”', 'newspack-sponsors' ),
-					$defaults['disclaimer']
-				),
-				'key'         => 'newspack_sponsors_default_disclaimer',
-				'type'        => 'textarea',
+				'label' => __( 'Default Sponsorship Disclaimer', 'newspack-sponsors' ),
+				'value' => $defaults['disclaimer'],
+				'key'   => 'newspack_sponsors_default_disclaimer',
+				'type'  => 'textarea',
 			],
 		];
 	}
@@ -174,25 +162,22 @@ final class Newspack_Sponsors_Settings {
 	 * @param array $setting Settings array.
 	 */
 	public static function newspack_sponsors_settings_callback( $setting ) {
-		$key         = $setting['key'];
-		$type        = $setting['type'];
-		$placeholder = $setting['placeholder'];
-		$value       = get_option( $key, false );
+		$key   = $setting['key'];
+		$type  = $setting['type'];
+		$value = ( '' !== get_option( $key, false ) ) ? get_option( $key, false ) : $setting['value'];
 
 		if ( 'textarea' === $type ) {
 			printf(
-				'<textarea id="%s" name="%s" class="widefat" rows="4" placeholder="%s">%s</textarea>',
+				'<textarea id="%s" name="%s" class="widefat" rows="4">%s</textarea>',
 				esc_attr( $key ),
 				esc_attr( $key ),
-				esc_attr( $placeholder ),
 				esc_attr( $value )
 			);
 		} else {
 			printf(
-				'<input type="text" id="%s" name="%s" placeholder="%s" value="%s" class="widefat" />',
+				'<input type="text" id="%s" name="%s" value="%s" class="widefat" />',
 				esc_attr( $key ),
 				esc_attr( $key ),
-				esc_attr( $placeholder ),
 				esc_attr( $value )
 			);
 		}

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { SelectControl, TextareaControl, TextControl, ToggleControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -63,11 +63,7 @@ const SidebarComponent = props => {
 			<TextControl
 				className="newspack-sponsors__text-control"
 				label={ __( 'Sponsor Flag Override (Optional)', 'newspack-sponsors' ) }
-				placeholder={ sprintf(
-					// Translators: placeholder text for Sponsor Flag field.
-					__( 'Default: “%s”', 'newspack-sponsors' ),
-					settings.flag || defaults.flag
-				) }
+				placeholder={ settings.flag || defaults.flag }
 				help={ __(
 					'The label for the flag that appears in lieu of category flags. If not empty, this field will override the site-wide setting.',
 					'newspack-sponsors'
@@ -79,10 +75,9 @@ const SidebarComponent = props => {
 			<TextareaControl
 				className="newspack-sponsors__textarea-control"
 				label={ __( 'Sponsor Disclaimer Override (Optional)', 'newspack-sponsors' ) }
-				placeholder={ sprintf(
-					// Translators: placeholder text for Sponsor Disclaimer field.
-					__( 'Default: “%s”', 'newspack-sponsors' ),
-					( settings.disclaimer || defaults.disclaimer ).replace( '[sponsor name]', title )
+				placeholder={ ( settings.disclaimer || defaults.disclaimer ).replace(
+					'[sponsor name]',
+					title
 				) }
 				help={ __(
 					'Text shown to explain sponsorship by this sponsor. If not empty, this field will override the site-wide setting.',
@@ -98,11 +93,7 @@ const SidebarComponent = props => {
 					'The prefix for the sponsor attribution that appears in lieu of author byline. If not empty, this field will override the site-wide setting.',
 					'newspack-sponsors'
 				) }
-				placeholder={ sprintf(
-					// Translators: placeholder text for Sponsor Byline Prefix field.
-					__( 'Default: “%s”', 'newspack-sponsors' ),
-					settings.byline || defaults.byline
-				) }
+				placeholder={ settings.byline || defaults.byline }
 				type="url"
 				value={ newspack_sponsor_byline_prefix }
 				onChange={ value => updateMetaValue( 'newspack_sponsor_byline_prefix', value ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of using input's placeholder for the default content, I suggest we display it as a value which will be easier for a user to tweak if needed.

### How to test the changes in this Pull Request:

1. Go to Sponsors > Settings. Notice the default settings are a placeholder.
2. Switch to this branch. Now the default settings are fully displayed.
3. Add new sponsor and publish, check the post if it's displayed correctly.
4. Edit the settings (via the Editor AND globally via Settings)
5. Check the post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
