### PR TITLE
Fix props mutation causing a crash in a strict mode

### DIFF
--- a/src/editor/taxonomy-panel/index.js
+++ b/src/editor/taxonomy-panel/index.js
@@ -32,10 +32,11 @@ export const TaxonomyPanel = PostTaxonomies => {
 			labels.name.toLowerCase(),
 			labels.name.toLowerCase()
 		);
+		const newProps = { ...props };
 
 		// Remove "Add new sponsors" link since sponsor terms are shadow terms of sponsor posts.
 		if ( 'newspack_spnsrs_tax' === slug ) {
-			props.hasCreateAction = false;
+			newProps.hasCreateAction = null;
 		}
 
 		return (
@@ -45,7 +46,7 @@ export const TaxonomyPanel = PostTaxonomies => {
 						<em>{ message }</em>
 					</p>
 				) }
-				<PostTaxonomies { ...props } />
+				<PostTaxonomies { ...newProps } />
 			</Fragment>
 		);
 	};

--- a/src/editor/taxonomy-panel/index.js
+++ b/src/editor/taxonomy-panel/index.js
@@ -32,12 +32,6 @@ export const TaxonomyPanel = PostTaxonomies => {
 			labels.name.toLowerCase(),
 			labels.name.toLowerCase()
 		);
-		const newProps = { ...props };
-
-		// Remove "Add new sponsors" link since sponsor terms are shadow terms of sponsor posts.
-		if ( 'newspack_spnsrs_tax' === slug ) {
-			newProps.hasCreateAction = null;
-		}
 
 		return (
 			<Fragment>
@@ -46,7 +40,11 @@ export const TaxonomyPanel = PostTaxonomies => {
 						<em>{ message }</em>
 					</p>
 				) }
-				<PostTaxonomies { ...newProps } />
+				<PostTaxonomies
+					{ ...props }
+					// Remove "Add new sponsors" link since sponsor terms are shadow terms of sponsor posts.
+					hasCreateAction={ 'newspack_spnsrs_tax' !== slug }
+				/>
 			</Fragment>
 		);
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue appearing when `SCRIPT_DEBUG` is set. Props is read-only, so mutating it probably causes a crash in the stricter mode enforced by `SCRIPT_DEBUG`.

### How to test the changes in this Pull Request:

1. On `master`
1. Enable `SCRIPT_DEBUG` in `wp-config.php`
2. Load a post with a sponsor set
3. Observe editor crashing
4. Switch to this branch, rebuild
5. Redo step 3, observe editor not crashing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
