### PR TITLE
Harden post type check to prevent notices

### DIFF
--- a/includes/class-newspack-sponsors-editor.php
+++ b/includes/class-newspack-sponsors-editor.php
@@ -99,8 +99,7 @@ final class Newspack_Sponsors_Editor {
 	 * Is editing a sponsor?
 	 */
 	public static function is_editing_sponsor() {
-		$post_type = get_post()->post_type;
-		return Core::NEWSPACK_SPONSORS_CPT === $post_type;
+		return Core::NEWSPACK_SPONSORS_CPT === get_post_type();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The following error message is triggered on every save when saving events calendar events:

```
[02-Sep-2020 17:48:21 UTC] PHP Notice:  Trying to get property 'post_type' of non-object in /wordpress/plugins/newspack-sponsors/1.2.0/includes/class-newspack-sponsors-editor.php on line 102
```

`get_post` can potentially return `null`, so the code should verify that a post was returned before getting fields from the post. This PR simplifies the post type check and prevents those sorts of issues from happening.

### How to test the changes in this Pull Request:

1. Behavior should be exactly the same before and after this change.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
