### PR TITLE
Bug fixes

### DIFF
--- a/includes/class-newspack-sponsors-core.php
+++ b/includes/class-newspack-sponsors-core.php
@@ -237,8 +237,23 @@ final class Newspack_Sponsors_Core {
 	 * Create a relationship between the Sponsors CPT and Sponsors tax.
 	 */
 	public static function create_shadow_relationship() {
-		add_action( 'wp_insert_post', [ __CLASS__, 'update_shadow_term' ], 10, 2 );
+		add_action( 'wp_insert_post', [ __CLASS__, 'update_or_delete_shadow_term' ], 10, 2 );
 		add_action( 'before_delete_post', [ __CLASS__, 'delete_shadow_term' ] );
+	}
+
+	/**
+	 * When a sponsor post changes status, add/update the shadow term if the status is `publish`, otherwise delete it.
+	 *
+	 * @param int   $post_id ID for the post being inserted or saved.
+	 * @param array $post Post object for the post being inserted or saved.
+	 * @return void
+	 */
+	public static function update_or_delete_shadow_term( $post_id, $post ) {
+		if ( 'publish' === $post->post_status ) {
+			self::update_shadow_term( $post_id, $post );
+		} else {
+			self::delete_shadow_term( $post_id );
+		}
 	}
 
 	/**

--- a/includes/newspack-sponsors-theme-helpers.php
+++ b/includes/newspack-sponsors-theme-helpers.php
@@ -182,11 +182,7 @@ function get_sponsors_for_archive( $term_id = null, $scope = null, $logo_options
 
 		$term = get_queried_object();
 	} else {
-		$term = get_term( $term_id, 'category' );
-
-		if ( empty( $term ) ) {
-			$term - get_term( $term_id, 'post_tag' );
-		}
+		$term = get_term_by( 'id', $term_id );
 	}
 
 	// Return false if there's no term for this $term_id.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Two bugfixes:

* When a sponsor post is unpublished (set to draft or trash status), the shadow taxonomy term remains available to select in the post Sponsors sidebar, making it possible to select an unpublished sponsor which will not be rendered on the front-end.
* When getting sponsors for a taxonomy other than category, a PHP warning is thrown.

Closes #38.
Closes #45.

### How to test the changes in this Pull Request:

#### Testing shadow term deletion

1. On `master`, create and publish a sponsor post.
2. Edit a post, expand the Sponsors sidebar panel and observe that the sponsor is available to select.
3. Set the sponsor post status to "draft". Edit the post again and observe that the sponsor is still available to select. Bonus: observe that if the draft sponsor selected and the post is updated, the post is rendered on the front-end without any sponsorship styles.
4. Check out this branch.
5. Reset the sponsor post status to `publish`, then `draft` (or just save the sponsor post without making any changes—as long as the status is still `draft`), then edit the post again. Confirm that the sponsor post is no longer available in the Sponsors sidebar.
6. Set the sponsor post status to `publish` and edit the post again. Confirm that the sponsor is once again available to select. 
7. Save the post and view on the front-end. Confirm that it's displayed with sponsorship styles on the front-end.
8. Trash the sponsor post. Edit the post again. Confirm that the sponsor is no longer selected nor available in the Sponsors sidebar. 
9. View the post on the front-end and observe that it's no longer displayed with sponsorship styles.


#### Testing the PHP warning on non-category term archives

1. On `master` with at least one published sponsor post existing on the site, view an archive for a tag term.
2. Observe the following PHP warning being thrown:

```
Notice: Object of class WP_Term could not be converted to int in /srv/www/newspack-dev/public_html/wp-content/plugins/newspack-sponsors/includes/newspack-sponsors-theme-helpers.php on line 188
```

3. Check out this branch.
4. Refresh the tag term archive page and confirm that the error is no longer thrown.
5. Additionally, confirm that if a post with a native sponsor is displayed in the tag term archive or a category archive, it's still shown with sponsorship styles in both archives.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
