### PR TITLE
feat: add support for Newspack Blocks

### DIFF
--- a/includes/class-newspack-sponsors-core.php
+++ b/includes/class-newspack-sponsors-core.php
@@ -88,7 +88,7 @@ final class Newspack_Sponsors_Core {
 			'public'       => false,
 			'show_ui'      => true,
 			'show_in_rest' => true,
-			'supports'     => [ 'editor', 'title', 'custom-fields', 'thumbnail' ],
+			'supports'     => [ 'editor', 'title', 'custom-fields', 'thumbnail', 'newspack_blocks' ],
 			'taxonomies'   => [ 'category', 'post_tag' ], // Regular post categories and tags.
 			'menu_icon'    => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyem0xLjQxIDE2LjA5VjIwaC0yLjY3di0xLjkzYy0xLjcxLS4zNi0zLjE2LTEuNDYtMy4yNy0zLjRoMS45NmMuMSAxLjA1LjgyIDEuODcgMi42NSAxLjg3IDEuOTYgMCAyLjQtLjk4IDIuNC0xLjU5IDAtLjgzLS40NC0xLjYxLTIuNjctMi4xNC0yLjQ4LS42LTQuMTgtMS42Mi00LjE4LTMuNjcgMC0xLjcyIDEuMzktMi44NCAzLjExLTMuMjFWNGgyLjY3djEuOTVjMS44Ni40NSAyLjc5IDEuODYgMi44NSAzLjM5SDE0LjNjLS4wNS0xLjExLS42NC0xLjg3LTIuMjItMS44Ny0xLjUgMC0yLjQuNjgtMi40IDEuNjQgMCAuODQuNjUgMS4zOSAyLjY3IDEuOTFzNC4xOCAxLjM5IDQuMTggMy45MWMtLjAxIDEuODMtMS4zOCAyLjgzLTMuMTIgMy4xNnoiIGZpbGw9IiNhMGE1YWEiLz48L3N2Zz4K',
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for `newspack_blocks` to the Sponsors CPT, so that it can be used in the Newspack Homepage Posts and Post Carousel blocks. Pairs with https://github.com/Automattic/newspack-blocks/pull/746, which enables support for other post types to Post Carousel.

### How to test the changes in this Pull Request:

1. Check out https://github.com/Automattic/newspack-blocks/pull/746 in Newspack Blocks.
2. On a post or page, add a Homepage Posts and Post Carousel block.
3. For each block, expand the "Post Types" sidebar panel and confirm that a "Sponsors" option is available.
4. Toggle on the "Sponsors" post type option and confirm that the blocks now include sponsors in their query results, and that toggling on Specific Posts mode lets you search for sponsors as well. (Must have at least one published sponsor post to test, of course.)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
