### PR TITLE
fix: ensure that sponsor post types can't be sponsored

### DIFF
--- a/includes/newspack-sponsors-theme-helpers.php
+++ b/includes/newspack-sponsors-theme-helpers.php
@@ -103,6 +103,11 @@ function get_sponsors_for_post( $post_id = null, $scope = null, $logo_options = 
 		return false;
 	}
 
+	// Sponsors can't sponsor other sponsors.
+	if ( Core::NEWSPACK_SPONSORS_CPT === $post->post_type ) {
+		return false;
+	}
+
 	$sponsors        = [];
 	$direct_sponsors = get_the_terms( $post_id, Core::NEWSPACK_SPONSORS_TAX );
 	$categories      = get_the_category( $post_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an edge case: adds a failsafe to ensure that when checking a post for sponsor terms, if the given post happens to be a sponsor itself, no results are returned.

### How to test the changes in this Pull Request:

With the current released state of the plugin, it's not possible to assign sponsor terms to sponsor post types. However, it was possible to do so with early dev versions of the plugin, so some older sites have sponsor CPTs floating around that still have sponsor terms assigned. When used in the Post Carousel or Homepage Posts blocks, these sponsors are shown with the "sponsored by" design.

It's not actually possible to test this with sponsors that have been created with the current version of the plugin, since the shadow term isn't registered for the sponsor post type. But I've tested with a test site that had sponsor CPTs with sponsor terms assigned and confirmed that this change fixes the issue. If you want to test yourself, you'll need to temporarily edit [this line](https://github.com/Automattic/newspack-sponsors/blob/master/includes/class-newspack-sponsors-core.php#L233) to the following:

```
register_taxonomy( self::NEWSPACK_SPONSORS_TAX, [ 'post', 'newspack_spnsrs_cpt' ], $tax_args );
```

Then:

1. Create at least two sponsors and add logos, URLs, etc.
2. Using WP CLI, look up the shadow term for one of the sponsors, and assign it to the post for the other sponsor. For example:

```
$ wp term list newspack_spnsrs_tax
+---------+------------------+----------------------+----------------------+-------------+--------+-------+
| term_id | term_taxonomy_id | name                 | slug                 | description | parent | count |
+---------+------------------+----------------------+----------------------+-------------+--------+-------+
| 341     | 341              | Sponsor A            | sponsor-a            |             | 0      | 1     |
| 414     | 414              | Sponsor B            | sponsor-b            |             | 0      | 0     |
+---------+------------------+----------------------+----------------------+-------------+--------+-------+

$ wp post list --post_type=newspack_spnsrs_cpt
+------+----------------------+----------------------+---------------------+-------------+
| ID   | post_title           | post_name            | post_date           | post_status |
+------+----------------------+----------------------+---------------------+-------------+
| 2439 | Sponsor A            | sponsor-a            | 2021-03-10 14:13:49 | publish     |
| 1443 | Sponsor B            | sponsor-b            | 2020-09-08 22:29:41 | publish     |
+------+----------------------+----------------------+---------------------+-------------+

$ wp post term add 2439 newspack_spnsrs_tax sponsor-b # assign shadow term for Sponsor B to post for Sponsor A
```

3. On `master`, add a Post Carousel block to a post or page. Under Post Types, select Sponsors.
4. Observe that the sponsor that has a sponsor term assigned is displayed with "Sponsored by" styles in the editor and on the front-end.
5. Check out this branch, confirm that the sponsor is no longer shown with "Sponsored by" styles either in the editor or on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
