### PR TITLE
feat: create filter to let other plugins add supported post types

### DIFF
--- a/includes/class-newspack-sponsors-core.php
+++ b/includes/class-newspack-sponsors-core.php
@@ -230,7 +230,12 @@ final class Newspack_Sponsors_Core {
 			'show_ui'       => true,
 		];
 
-		register_taxonomy( self::NEWSPACK_SPONSORS_TAX, 'post', $tax_args );
+		$post_types = apply_filters(
+			'newspack_sponsors_post_types',
+			[ 'post', 'page' ]
+		);
+
+		register_taxonomy( self::NEWSPACK_SPONSORS_TAX, $post_types, $tax_args );
 	}
 
 	/**

--- a/includes/class-newspack-sponsors-core.php
+++ b/includes/class-newspack-sponsors-core.php
@@ -254,11 +254,44 @@ final class Newspack_Sponsors_Core {
 	 * @return void
 	 */
 	public static function update_or_delete_shadow_term( $post_id, $post ) {
-		if ( 'publish' === $post->post_status ) {
+		// If the post is a valid post, update or create the shadow term. Otherwise, delete it.
+		if ( self::should_update_shadow_term( $post ) ) {
 			self::update_shadow_term( $post_id, $post );
 		} else {
 			self::delete_shadow_term( $post_id );
 		}
+	}
+
+	/**
+	 * Check whether a given post object should have a shadow term.
+	 *
+	 * @param object $post Post object to check.
+	 * @return bool True if the post should have a shadow term, otherwise false.
+	 */
+	public static function should_update_shadow_term( $post ) {
+		$should_update_shadow_term = true;
+
+		// If post isn't published.
+		if ( 'publish' !== $post->post_status ) {
+			$should_update_shadow_term = false;
+		}
+
+		// If post lacks a valid title.
+		if ( ! $post->post_title || 'Auto Draft' === $post->post_title ) {
+			$should_update_shadow_term = false;
+		}
+
+		// If post lacks a valid slug.
+		if ( ! $post->post_name ) {
+			$should_update_shadow_term = false;
+		}
+
+		// If post isn't the right post type.
+		if ( self::NEWSPACK_SPONSORS_CPT !== $post->post_type ) {
+			return false;
+		}
+
+		return $should_update_shadow_term;
 	}
 
 	/**
@@ -270,12 +303,7 @@ final class Newspack_Sponsors_Core {
 	 */
 	public static function update_shadow_term( $post_id, $post ) {
 		// Bail if we don't have a valid post or post type.
-		if ( empty( $post ) || self::NEWSPACK_SPONSORS_CPT !== $post->post_type ) {
-			return false;
-		}
-
-		// Bail if post is an auto draft.
-		if ( 'auto-draft' === $post->post_status || 'Auto Draft' === $post->post_title ) {
+		if ( empty( $post ) ) {
 			return false;
 		}
 
@@ -333,7 +361,13 @@ final class Newspack_Sponsors_Core {
 			return false;
 		}
 
-		$shadow_term = get_term_by( 'name', $post->post_title, self::NEWSPACK_SPONSORS_TAX );
+		// Try finding the shadow term by slug first.
+		$shadow_term = get_term_by( 'slug', $post->post_name, self::NEWSPACK_SPONSORS_TAX );
+
+		// If we can't find a term by slug, the post slug may have been updated. Try finding by title instead.
+		if ( empty( $shadow_term ) ) {
+			$shadow_term = get_term_by( 'name', $post->post_title, self::NEWSPACK_SPONSORS_TAX );
+		}
 
 		if ( empty( $shadow_term ) ) {
 			return false;

--- a/includes/newspack-sponsors-theme-helpers.php
+++ b/includes/newspack-sponsors-theme-helpers.php
@@ -42,7 +42,12 @@ function get_all_sponsors( $id = null, $scope = null, $type = null, $logo_option
 
 	// If no type given, try to guess based on the current page context.
 	if ( null === $type ) {
-		if ( is_singular( 'post' ) ) {
+		$post_types = apply_filters(
+			'newspack_sponsors_post_types',
+			[ 'post', 'page' ]
+		);
+
+		if ( is_singular( $post_types ) ) {
 			$type = 'post';
 		} elseif ( is_archive() ) {
 			$type = 'archive';
@@ -85,8 +90,13 @@ function get_sponsors_for_post( $post_id = null, $scope = null, $logo_options = 
 		return false;
 	}
 
+	$post_types = apply_filters(
+		'newspack_sponsors_post_types',
+		[ 'post', 'page' ]
+	);
+
 	if ( null === $post_id ) {
-		if ( ! is_singular( 'post' ) ) {
+		if ( ! is_singular( $post_types ) ) {
 			return new WP_Error(
 				'newspack-sponsors__is_not_post',
 				__( 'Please provide a $post_id if not invoking within a single post.' )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a filter which will let other plugins define additional supported post types beyond regular posts and pages.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-listings/pull/65.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
