### PR TITLE
fix: ad suppression tweak

### DIFF
--- a/includes/class-newspack-sponsors-core.php
+++ b/includes/class-newspack-sponsors-core.php
@@ -56,6 +56,9 @@ final class Newspack_Sponsors_Core {
 	 * @param int  $post_id Post ID.
 	 */
 	public static function suppress_ads( $should_display, $post_id ) {
+		if ( ! is_single() ) {
+			return $should_display;
+		}
 		$sponsors = get_sponsors_for_post( $post_id );
 		if ( $sponsors && count( $sponsors ) ) {
 			return false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Slight tweak to #62 

### How to test the changes in this Pull Request:

1. On `master`, load the WP Admin dashboard, observe a PHP notice originating from this plugin
2. Switch to this branch, observe no notice shown
3. Observe that ads are still not displayed on sponsored posts

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->