### PR TITLE
feat: add a global setting to suppress ads on sponsored posts

### DIFF
--- a/includes/class-newspack-sponsors-core.php
+++ b/includes/class-newspack-sponsors-core.php
@@ -10,6 +10,8 @@
 
 namespace Newspack_Sponsors;
 
+use Newspack_Sponsors\Newspack_Sponsors_Settings as Settings;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -59,8 +61,10 @@ final class Newspack_Sponsors_Core {
 		if ( ! is_single() ) {
 			return $should_display;
 		}
-		$sponsors = get_sponsors_for_post( $post_id );
-		if ( $sponsors && count( $sponsors ) ) {
+
+		$suppress_ads = Settings::get_settings( 'suppress' );
+		$sponsors     = get_sponsors_for_post( $post_id );
+		if ( boolval( $suppress_ads ) && $sponsors && count( $sponsors ) ) {
 			return false;
 		}
 		return $should_display;

--- a/includes/class-newspack-sponsors-settings.php
+++ b/includes/class-newspack-sponsors-settings.php
@@ -40,6 +40,7 @@ final class Newspack_Sponsors_Settings {
 				),
 				get_bloginfo( 'name' )
 			),
+			'suppress'   => false,
 		];
 
 		return $defaults;
@@ -48,14 +49,17 @@ final class Newspack_Sponsors_Settings {
 	/**
 	 * Get current site-wide settings, or defaults if not set.
 	 *
+	 * @param string $setting Key name of a setting to retrieve. If given, only the matching setting's value will be returned.
+	 *
 	 * @return array Array of current site-wide settings.
 	 */
-	public static function get_settings() {
+	public static function get_settings( $setting = null ) {
 		$defaults = self::get_default_settings();
 		$settings = [
 			'byline'     => get_option( 'newspack_sponsors_default_byline', $defaults['byline'] ),
 			'flag'       => get_option( 'newspack_sponsors_default_flag', $defaults['flag'] ),
 			'disclaimer' => get_option( 'newspack_sponsors_default_disclaimer', $defaults['disclaimer'] ),
+			'suppress'   => get_option( 'newspack_sponsors_suppress_ads', $defaults['suppress'] ),
 		];
 
 		// Guard against empty strings, which can happen if an option is set and then unset.
@@ -63,6 +67,10 @@ final class Newspack_Sponsors_Settings {
 			if ( empty( $value ) ) {
 				$settings[ $key ] = $defaults[ $key ];
 			}
+		}
+
+		if ( $setting && isset( $settings[ $setting ] ) ) {
+			return $settings[ $setting ];
 		}
 
 		return $settings;
@@ -94,6 +102,12 @@ final class Newspack_Sponsors_Settings {
 				'value' => $defaults['disclaimer'],
 				'key'   => 'newspack_sponsors_default_disclaimer',
 				'type'  => 'textarea',
+			],
+			[
+				'label' => __( 'Suppress Ads for All Sponsored Posts', 'newspack-sponsors' ),
+				'value' => $defaults['suppress'],
+				'key'   => 'newspack_sponsors_suppress_ads',
+				'type'  => 'checkbox',
 			],
 		];
 	}
@@ -166,7 +180,15 @@ final class Newspack_Sponsors_Settings {
 		$type  = $setting['type'];
 		$value = ( '' !== get_option( $key, false ) ) ? get_option( $key, false ) : $setting['value'];
 
-		if ( 'textarea' === $type ) {
+		if ( 'checkbox' === $type ) {
+			printf(
+				'<input type="checkbox" id="%s" name="%s" %s />',
+				esc_attr( $key ),
+				esc_attr( $key ),
+				! empty( $value ) ? 'checked' : '',
+				esc_attr( $key )
+			);
+		} elseif ( 'textarea' === $type ) {
 			printf(
 				'<textarea id="%s" name="%s" class="widefat" rows="4">%s</textarea>',
 				esc_attr( $key ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Partially reverts the behavior from #62, which automatically suppresses all ads for all sponsored posts. This PR adds a new toggle option in plugin settings to do so (disabled by default), restoring the prior behavior but allowing publishers to opt into the new suppression.

Closes #67.

### How to test the changes in this Pull Request:

1. On `master`, publish a post with at least one sponsor and ensure at least one ad is displayed in a global position and/or block or widget.
2. View the sponsored post on the front-end; observe that no ads are displayed on the post.
3. Check out this branch. Refresh the sponsored post; confirm that ads are now displayed.
4. Go to **WP admin > Sponsors > Settings** and confirm there's a new option here, disabled by default:

<img width="261" alt="Screen Shot 2021-09-23 at 4 15 50 PM" src="https://user-images.githubusercontent.com/2230142/134591232-374b3b48-de05-4f3c-9548-1cd4dbc34481.png">

5. Toggle it on and save, refresh the sponsored post; confirm that the ads are no longer displayed.
6. Edit the sponsored post and test the Newspack Ads Settings toggle to ensure that it still behaves as expected for the individual post when ads aren't suppressed globally for sponsored posts:

<img width="276" alt="Screen Shot 2021-09-23 at 4 17 01 PM" src="https://user-images.githubusercontent.com/2230142/134591357-b1641701-9ef1-45d2-a843-2a62ab9fd970.png">
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
