### PR TITLE
chore: automatically assign dependabot PRs to Newspack Product group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'daily'
+    # Add reviewers
+    reviewers:
+      - 'Automattic/newspack-product'
 
   # Enable version updates for Composer
   - package-ecosystem: 'composer'
@@ -19,3 +22,6 @@ updates:
     # Check for updates every day (weekdays)
     schedule:
       interval: 'daily'
+    # Add reviewers
+    reviewers:
+      - 'Automattic/newspack-product'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Now that Dependabot (#74) is confirmed to be working, we can improve it even more by automatically pinging the @Automattic/newspack-product team on all its PRs.

### How to test the changes in this Pull Request:

Can't really test this until it gets merged, but after that all Dependabot PRs should be automatically assigned to the Newspack Product group as reviewers.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
