### PR TITLE
fix(wp5.9): taxonomy panel filter

### DIFF
--- a/src/editor/taxonomy-panel/index.js
+++ b/src/editor/taxonomy-panel/index.js
@@ -32,7 +32,7 @@ export const TaxonomyPanel = PostTaxonomies => {
 				'%1$s one or more post %2$s to associate this sponsor with those %3$s.',
 				'newspack-sponsors'
 			),
-			// Translators: "Select" terms if none added yet, or "Add" terms if there's at least one selected already.
+			// Translators: "Select" terms if the taxonomy is hierarchical, or "Add" terms if not.
 			hierarchical ? __( 'Select ', 'newspack-sponsors' ) : __( 'Add ', 'newspack-sponsors' ),
 			label,
 			label

--- a/src/editor/taxonomy-panel/index.js
+++ b/src/editor/taxonomy-panel/index.js
@@ -20,8 +20,12 @@ export const TaxonomyPanel = PostTaxonomies => {
 			return <PostTaxonomies { ...props } />;
 		}
 
-		const { slug, taxonomy } = props;
-		const { hierarchical, labels } = taxonomy;
+		const { slug } = props;
+		const hierarchical = 'category' === slug;
+		const label =
+			'category' === slug
+				? __( 'categories', 'newspack-sponsors' )
+				: __( 'tags', 'newspack-sponsors' );
 		const message = sprintf(
 			// Translators: explanation for applying sponsors to a taxonomy term.
 			__(
@@ -30,8 +34,8 @@ export const TaxonomyPanel = PostTaxonomies => {
 			),
 			// Translators: "Select" terms if none added yet, or "Add" terms if there's at least one selected already.
 			hierarchical ? __( 'Select ', 'newspack-sponsors' ) : __( 'Add ', 'newspack-sponsors' ),
-			labels.name.toLowerCase(),
-			labels.name.toLowerCase()
+			label,
+			label
 		);
 
 		return (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Looks like the props passed to the `editor.PostTaxonomyType` filter have changed in WP 5.9. It no longer passes a `taxonomy` prop containing info about the taxonomy, such as whether it's hierarchical or its human-readable labels. However, it does still pass the `slug` prop, which we can still use to determine whether the panel being rendered is for Categories or Tags. Relying on this `slug` prop alone should fix errors in WP 5.9 as well as maintain backwards compatibility with WP 5.8 and earlier.

Unrelated, but also adds the missing `CHANGELOG.md` file that will be needed for the new post-release CI job implemented in #141.

Fixes #148.

### How to test the changes in this Pull Request:

1. On `master`, edit a sponsor and attempt to expand the Categories or Tags sidebar panels.
2. Observe an editor crash as described in #148.
3. Check out this branch rebuild, refresh, and confirm that the crash no longer happens and that you can once again add/remove categories and tags using both sidebar panels.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
