### PR TITLE
fix: do not include child terms for sponsored categories

### DIFF
--- a/includes/newspack-sponsors-theme-helpers.php
+++ b/includes/newspack-sponsors-theme-helpers.php
@@ -307,9 +307,10 @@ function get_sponsor_posts_for_terms( $terms ) {
 	foreach ( $terms as $term ) {
 		if ( ! empty( $term->taxonomy ) && ! empty( $term->term_id ) ) {
 			$tax_query_args[] = [
-				'taxonomy' => $term->taxonomy,
-				'field'    => 'term_id',
-				'terms'    => $term->term_id,
+				'taxonomy'         => $term->taxonomy,
+				'field'            => 'term_id',
+				'terms'            => $term->term_id,
+				'include_children' => false,
 			];
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When querying sponsors for a hierarchical term, avoids querying children so as not to mark posts of non-sponsored child terms as sponsored.

Closes #64.

### How to test the changes in this Pull Request:

Confirm that #64 is not reproducible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
