### PR TITLE
feat: ad targeting for gpt

### DIFF
--- a/includes/class-newspack-sponsors-core.php
+++ b/includes/class-newspack-sponsors-core.php
@@ -79,11 +79,13 @@ final class Newspack_Sponsors_Core {
 	 * @return array
 	 */
 	public static function ad_targeting( $targeting ) {
-		if ( ! is_singular() ) {
-			return $targeting;
+		$sponsors = [];
+		if ( is_singular() ) {
+			$sponsors = get_sponsors_for_post( get_the_ID() );
+		} elseif ( is_archive() ) {
+			$sponsors = get_sponsors_for_archive();
 		}
-		$sponsors = get_sponsors_for_post( get_the_ID() );
-		if ( ! empty( $sponsors ) && ! isset( $targeting['sponsors'] ) ) {
+		if ( ! is_wp_error( $sponsors ) && ! empty( $sponsors ) && ! isset( $targeting['sponsors'] ) ) {
 			$targeting['sponsors'] = array_map(
 				function( $sponsor ) {
 					return $sponsor['sponsor_slug'];

--- a/includes/class-newspack-sponsors-core.php
+++ b/includes/class-newspack-sponsors-core.php
@@ -49,6 +49,7 @@ final class Newspack_Sponsors_Core {
 	public function __construct() {
 		add_action( 'init', [ __CLASS__, 'init' ] );
 		add_filter( 'newspack_ads_should_show_ads', [ __CLASS__, 'suppress_ads' ], 10, 2 );
+		add_filter( 'newspack_ads_ad_targeting', [ __CLASS__, 'ad_targeting' ], 10, 2 );
 	}
 
 	/**
@@ -68,6 +69,29 @@ final class Newspack_Sponsors_Core {
 			return false;
 		}
 		return $should_display;
+	}
+
+	/**
+	 * Set ad targeting for sponsored posts.
+	 *
+	 * @param array $targeting Ad targeting.
+	 *
+	 * @return array
+	 */
+	public static function ad_targeting( $targeting ) {
+		if ( ! is_singular() ) {
+			return $targeting;
+		}
+		$sponsors = get_sponsors_for_post( get_the_ID() );
+		if ( ! empty( $sponsors ) && ! isset( $targeting['sponsors'] ) ) {
+			$targeting['sponsors'] = array_map(
+				function( $sponsor ) {
+					return $sponsor['sponsor_slug'];
+				},
+				$sponsors
+			);
+		}
+		return $targeting;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements ad targeting for sponsors.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-ads/issues/397

### How to test the changes in this Pull Request:

#### Posts

1. Check out this branch and visit a post that contains ads with the `?googfc` parameter
2. Using the overlayed ad inspection tool, click "Open targeting info"
3. Observe the sponsor slug being targeted using the `sponsors` key
4. Add a second sponsor to the post, refresh the page and confirm both sponsors are targeted

#### Categories

1. Add a sponsor to a category and make sure you have at least one global placement with a GAM unit.
2. Visit the category archive page with `?googfc`
3. Confirm the slots are targeted with the sponsor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
