### PR TITLE
chore: fix path to plugin file for semantic release job

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "",
 	"scripts": {
 		"cm": "newspack-scripts commit",
-		"semantic-release": "newspack-scripts release --files=sponsors.php",
+		"semantic-release": "newspack-scripts release --files=newspack-sponsors.php",
 		"start": "npm ci && newspack-scripts watch",
 		"watch": "newspack-scripts watch",
 		"build": "newspack-scripts build",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`package.json` has the wrong file path to this plugin's main file for the semantic release job, which should update the version number automatically upon release.

### How to test the changes in this Pull Request:

Nothing really to test until a new alpha or prod release is built. After that, check in the `newspack-sponsors.php` file to confirm that the version number is updated to match the latest release.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
