### PR TITLE
Fix: update Sponsorship Byline description

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -235,7 +235,7 @@ final class Core {
 			'post',
 			'newspack_sponsor_native_byline_display',
 			[
-				'description'       => __( 'Display the sponsorship only, the author byline only, or both.', 'newspack-sponsors' ),
+				'description'       => __( 'Display the sponsor only in the byline, or both the sponsor and post author.', 'newspack-sponsors' ),
 				'type'              => 'string',
 				'default'           => self::is_sponsor() ? 'sponsor' : 'inherit',
 				'sanitize_callback' => 'sanitize_text_field',

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -102,7 +102,7 @@ const SidebarComponent = props => {
 						value={ newspack_sponsor_native_byline_display || bylineDefault }
 						options={ bylineOptions }
 						onChange={ value => updateMetaValue( 'newspack_sponsor_native_byline_display', value ) }
-						help={ __( 'Show the sponsor, the author byline, or both.', 'newspack-sponsors' ) }
+						help={ __( 'Display the sponsor only in the byline, or both the sponsor and post author.', 'newspack-sponsors' ) }
 					/>
 					<SelectControl
 						className="newspack-sponsors__select-control"

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -102,7 +102,10 @@ const SidebarComponent = props => {
 						value={ newspack_sponsor_native_byline_display || bylineDefault }
 						options={ bylineOptions }
 						onChange={ value => updateMetaValue( 'newspack_sponsor_native_byline_display', value ) }
-						help={ __( 'Display the sponsor only in the byline, or both the sponsor and post author.', 'newspack-sponsors' ) }
+						help={ __(
+							'Display the sponsor only in the byline, or both the sponsor and post author.',
+							'newspack-sponsors'
+						) }
 					/>
 					<SelectControl
 						className="newspack-sponsors__select-control"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the description for the Sponsorship Byline Display -- it originally implied that you could display the only post author, but that shouldn't be an option (and isn't one in the dropdown). It should only let you show the sponsor, or both the author and sponsor. 

Closes #206

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Edit a Sponsor and confirm that the Sponsorship Byline Display description indicates you can only pick the sponsor, or sponsor and author.
3. Edit a post and add a sponsor; confirm the per-post override Sponsorship Byline Display description indicates you can only pick the sponsor, or sponsor and author.
4. Confirm that the new description makes sense: "Display the sponsor only in the byline, or both the sponsor and post author."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
