### PR TITLE
fix: update CI orb newspack-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.1
+  newspack: adekbadek/newspack@1.4.2
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.2
+  newspack: adekbadek/newspack@1.4.3
 
 workflows:
   version: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@rushstack/eslint-patch": "^1.2.0",
 				"eslint": "^7.32.0",
 				"lint-staged": "^13.0.3",
-				"newspack-scripts": "^4.3.7",
+				"newspack-scripts": "^4.3.8",
 				"postcss-scss": "^4.0.5",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 				"stylelint": "^14.9.1"
@@ -17554,9 +17554,9 @@
 			"dev": true
 		},
 		"node_modules/newspack-scripts": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.7.tgz",
-			"integrity": "sha512-twxZz9tRnxCIAUlfdppxaFiClt7WJIOoQv57+d4GU5sPQk6zOdXNtqZkWXoptRICWbgzsLzDxoSilKCvV7Ivtw==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
+			"integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -43031,9 +43031,9 @@
 			"dev": true
 		},
 		"newspack-scripts": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.7.tgz",
-			"integrity": "sha512-twxZz9tRnxCIAUlfdppxaFiClt7WJIOoQv57+d4GU5sPQk6zOdXNtqZkWXoptRICWbgzsLzDxoSilKCvV7Ivtw==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
+			"integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@rushstack/eslint-patch": "^1.2.0",
 		"eslint": "^7.32.0",
 		"lint-staged": "^13.0.3",
-		"newspack-scripts": "^4.3.7",
+		"newspack-scripts": "^4.3.8",
 		"postcss-scss": "^4.0.5",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 		"stylelint": "^14.9.1"


### PR DESCRIPTION
Update `newspack-scripts` and CI orb. The latest version combo will handle building JS files on CI better:

- version `1.4.2` of the orb adds setting node version according to the project's `.nvmrc` file prior to installing npm modules and building the JS files
- version `4.3.8` of `newspack-scripts` removes a hacky partial fix for issues caused by node version mismatch