### PR TITLE
fix: add failsafe to ensure that Sponsors queries contain only sponsors CPT

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -528,7 +528,7 @@ final class Core {
 	 */
 	public static function ensure_only_sponsors( $query ) {
 		if ( boolval( $query->get( 'is_sponsors' ) ) ) {
-			$query->set( 'post_type', self::NEWSPACK_SPONSORS_CPT );
+			$query->set( 'post_type', self::NEWSPACK_SPONSORS_CPT ); // phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
 		}
 	}
 }

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -50,6 +50,7 @@ final class Core {
 		add_action( 'init', [ __CLASS__, 'init' ] );
 		add_filter( 'newspack_ads_should_show_ads', [ __CLASS__, 'suppress_ads' ], 10, 2 );
 		add_filter( 'newspack_ads_ad_targeting', [ __CLASS__, 'ad_targeting' ], 10, 2 );
+		add_action( 'pre_get_posts', [ __CLASS__, 'ensure_only_sponsors' ] );
 	}
 
 	/**
@@ -517,6 +518,18 @@ final class Core {
 		}
 
 		return $new_term;
+	}
+
+	/**
+	 * Failsafe to ensure that sponsors queries only fetch sponsors post types.
+	 * Other plugins may have query filters to add other post types to queries.
+	 *
+	 * @param WP_Query $query Query.
+	 */
+	public static function ensure_only_sponsors( $query ) {
+		if ( boolval( $query->get( 'is_sponsors' ) ) ) {
+			$query->set( 'post_type', self::NEWSPACK_SPONSORS_CPT );
+		}
 	}
 }
 

--- a/includes/theme-helpers.php
+++ b/includes/theme-helpers.php
@@ -285,6 +285,7 @@ function is_duplicate_sponsor( $sponsors, $id ) {
 function get_related_post( $slug ) {
 	$related_post = new \WP_Query(
 		[
+			'is_sponsors'    => 1,
 			'post_type'      => Core::NEWSPACK_SPONSORS_CPT,
 			'posts_per_page' => 1,
 			'post_status'    => 'publish',
@@ -333,6 +334,7 @@ function get_sponsor_posts_for_terms( $terms ) {
 
 	$sponsor_posts = new \WP_Query(
 		[
+			'is_sponsors'    => 1,
 			'post_type'      => Core::NEWSPACK_SPONSORS_CPT,
 			'posts_per_page' => 100,
 			'post_status'    => 'publish',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a failsafe to ensure that WP queries originating in this plugin target ONLY sponsor CPTs, even if other plugins are adding other post types to queries.

### How to test the changes in this Pull Request:

Very difficult to replicate—please DM me for testing instructions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
