### PR TITLE
fix: remove check for default meta values that isn’t working

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -238,7 +238,7 @@ final class Core {
 			[
 				'description'       => __( 'Display the sponsor only in the byline, or both the sponsor and post author.', 'newspack-sponsors' ),
 				'type'              => 'string',
-				'default'           => self::is_sponsor() ? 'sponsor' : 'inherit',
+				'default'           => 'inherit',
 				'sanitize_callback' => 'sanitize_text_field',
 				'single'            => true,
 				'show_in_rest'      => true,
@@ -253,7 +253,7 @@ final class Core {
 			[
 				'description'       => __( 'Display the sponsor only, or display categories alongside the sponsor.', 'newspack-sponsors' ),
 				'type'              => 'string',
-				'default'           => self::is_sponsor() ? 'sponsor' : 'inherit',
+				'default'           => 'inherit',
 				'sanitize_callback' => 'sanitize_text_field',
 				'single'            => true,
 				'show_in_rest'      => true,
@@ -268,7 +268,7 @@ final class Core {
 			[
 				'description'       => __( 'Display the underwriter blurb in standard or simple-text format.', 'newspack-sponsors' ),
 				'type'              => 'string',
-				'default'           => self::is_sponsor() ? 'standard' : 'inherit',
+				'default'           => 'inherit',
 				'sanitize_callback' => 'sanitize_text_field',
 				'single'            => true,
 				'show_in_rest'      => true,
@@ -283,7 +283,7 @@ final class Core {
 			[
 				'description'       => __( 'Display the underwriter blurb at the top or bottom of the post.', 'newspack-sponsors' ),
 				'type'              => 'string',
-				'default'           => self::is_sponsor() ? 'top' : 'inherit',
+				'default'           => 'inherit',
 				'sanitize_callback' => 'sanitize_text_field',
 				'single'            => true,
 				'show_in_rest'      => true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Could be a chore, too, because it doesn't change any behavior in the plugin. But it removes a check and condition that isn't working. Because `register_meta` is happening on the `init` hook, it's too early to determine the post type, so the default values for several meta fields are always `inherit`. This PR makes this explicit.

Related to https://github.com/Automattic/newspack-theme/pull/2061 but isn't a blocker to that PR.

### How to test the changes in this Pull Request:

Nothing really to test—you can confirm that `get_post_meta` with the following fields always returns `inherit` by default:

- `newspack_sponsor_sponsorship_scope`
- `newspack_sponsor_native_byline_display`
- `newspack_sponsor_underwriter_style`
- `newspack_sponsor_underwriter_placement`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
