### PR TITLE
feat: add helper function to get all sponsored terms

### DIFF
--- a/includes/theme-helpers.php
+++ b/includes/theme-helpers.php
@@ -355,6 +355,65 @@ function get_sponsor_posts_for_terms( $terms ) {
 }
 
 /**
+ * Get all sponsored terms.
+ * 
+ * @return array|boolean An associative array keyed by taxonomy name with an array of sponsored term IDs for each, or false if no sponsored terms.
+ */
+function get_all_sponsored_terms() {
+	$taxonomies = \get_object_taxonomies( Core::NEWSPACK_SPONSORS_CPT );
+	if ( empty( $taxonomies ) ) {
+		return false;
+	}
+	
+	$tax_query_args = array_map(
+		$taxonomies,
+		function( $taxonomy ) {
+			return [
+				'taxonomy' => $taxonomy,
+				'operator' => 'EXISTS',
+			];
+		}
+	);
+
+	$tax_query_args['relation'] = 'OR';
+	$sponsors_with_terms        = new \WP_Query(
+		[
+			'is_sponsors'    => 1,
+			'fields'         => 'ids',
+			'post_type'      => Core::NEWSPACK_SPONSORS_CPT,
+			'posts_per_page' => 100,
+			'post_status'    => 'publish',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			'tax_query'      => $tax_query_args,
+		]
+	);
+
+	if ( empty( $sponsors_with_terms->posts ) ) {
+		return false;
+	}
+
+	$sponsored_terms = \get_terms(
+		[
+			'taxonomy'   => $taxonomies,
+			'object_ids' => $sponsors_with_terms->posts,
+		]
+	);
+
+	return array_reduce(
+		$sponsored_terms,
+		function( $acc, $term ) {
+			if ( ! isset( $acc[ $term->taxonomy ] ) ) {
+				$acc[ $term->taxonomy ] = [];
+			}
+
+			$acc[ $term->taxonomy ][] = $term->term_id;
+			return $acc;
+		},
+		[]
+	);
+}
+
+/**
  * Formats a post object into a sponsor object, for ease of theme developer use.
  *
  * @param array  $post Post object to convert.

--- a/includes/theme-helpers.php
+++ b/includes/theme-helpers.php
@@ -366,13 +366,13 @@ function get_all_sponsored_terms() {
 	}
 	
 	$tax_query_args = array_map(
-		$taxonomies,
 		function( $taxonomy ) {
 			return [
 				'taxonomy' => $taxonomy,
 				'operator' => 'EXISTS',
 			];
-		}
+		},
+		$taxonomies
 	);
 
 	$tax_query_args['relation'] = 'OR';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a helper function to get an associative array of taxonomies with sponsored term IDs. So if you have some sponsors assigned to categories and tags, the result should look like this:

```php
[
  "category" => [ 1, 2, 3 ],
  "post_tag" => [ 4, 5, 6 ],
]
```

The key is the name/slug of the taxonomy, and the value is an array of term IDs that are assigned to any sponsor CPT post. Only taxonomies that have any sponsored terms will exist in the response.

Required for https://github.com/Automattic/newspack-newsletters/pull/1261.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-newsletters/pull/1261. You can also run `wp shell` and run `\Newspack_Sponsors\get_all_sponsored_terms()` to test the output. If you have any sponsors with categories or tags, it should return an array as above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
