### PR TITLE
fix: make sure sponsored categories, tags show sponsor info

### DIFF
--- a/includes/theme-helpers.php
+++ b/includes/theme-helpers.php
@@ -223,13 +223,13 @@ function get_sponsors_for_archive( $term_id = null, $scope = null, $logo_options
 		if ( ! is_archive() ) {
 			return new WP_Error(
 				'newspack-sponsors__is_not_archive',
-				__( 'Please provide a $term_id if not invoking within a term archive page.' )
+				__( 'Please provide a $term_id if not invoking within a term archive page.', 'newspack-sponsors' )
 			);
 		}
 
 		$term = get_queried_object();
 	} else {
-		$term = get_term_by( 'id', $term_id );
+		$term = get_term_by( 'term_taxonomy_id', $term_id );
 	}
 
 	// Return false if there's no term for this $term_id.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a regression in the Sponsors plugin, where sponsored categories and tags stopped displaying the sponsor information at the top of their individual archive pages. 

This one is a little weird. Just looking at releases, this seems to have stopped working between [1.2.1](https://github.com/Automattic/newspack-sponsors/releases/tag/v1.2.1) and [1.3.0](https://github.com/Automattic/newspack-sponsors/compare/v1.2.1...v1.3.0), but I'm not actually sure why -- the changes in 1.3.0 alone don't seem like enough. 

On top of that, the fix I landed on was something that was never in this part of the plugin -- the docs for `get_term_by()` say that the taxonomy is optional only if you're using `term_taxonomy_id`, but `id` definitely worked for a while. So I'm not sure if this is the best approach, or if it'd be better to pass the taxonomy to `get_term_by()`, or something else.  Feedback welcome!

See 1200550061930446-as-1206174629624809

### How to test the changes in this Pull Request:

1. Set up at least one sponsored category and at least one sponsored tag, and apply posts to each.
2. View the archive of one of these sponsored categories or tags, and note that it looks like a regular archive. 

<img width="946" alt="image" src="https://github.com/Automattic/newspack-sponsors/assets/177561/ff8f3248-d846-432b-b297-00199bf3767c">

3. Apply the PR.
4. Refresh your archive; confirm that the sponsor's logo and description now appear at the top, and you no longer have an individual sponsor label for each post, but just at the top:

<img width="954" alt="image" src="https://github.com/Automattic/newspack-sponsors/assets/177561/19496aa5-18bb-4272-9ffd-60bf62d4c55e">

5. Check your other sponsored archives, and make sure they also look like this (both a category and tag).
6. Check some non-sponsored archives -- tags, categories, and author -- and sponsored posts in non-sponsored categories, and make sure they're displaying as expected. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
