### PR TITLE
feat: ensure regenerator-runtime is available (for WP 6.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"newspack-scripts": "^5.5.0",
 				"postcss-scss": "^4.0.9",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
+				"regenerator-runtime": "^0.14.1",
 				"stylelint": "^15.11.0"
 			}
 		},
@@ -1966,6 +1967,18 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"dev": true
+		},
+		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"dev": true
 		},
 		"node_modules/@babel/template": {
 			"version": "7.18.6",
@@ -7757,26 +7770,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/array.prototype.filter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
-			"integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array.prototype.find": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.1.tgz",
@@ -8661,72 +8654,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"node_modules/cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio/node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
 		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
@@ -9939,23 +9866,6 @@
 				"source-map": "~0.6.1"
 			}
 		},
-		"node_modules/css-select": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.1.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"nth-check": "^2.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
 		"node_modules/css-select-base-adapter": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
@@ -9982,19 +9892,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/css.escape": {
@@ -10804,13 +10701,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -10847,34 +10737,6 @@
 			"integrity": "sha512-LwNVg3GJOprWDO+QhLL1Z9MMgWe/KAFLxVWKzjRTxNSPn8/LLDIfmuG71YHznXCqaqTjvHJDYO1MEAgX6XCNbQ==",
 			"dev": true
 		},
-		"node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/dom-serializer/node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/domelementtype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -10906,37 +10768,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0"
-			},
-			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domhandler?sponsor=1"
-			}
-		},
-		"node_modules/domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
 		"node_modules/dot-case": {
@@ -11199,40 +11030,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/enzyme-matchers": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-7.1.2.tgz",
@@ -11361,13 +11158,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/es-module-lexer": {
 			"version": "0.9.3",
@@ -13413,20 +13203,6 @@
 			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
-		"node_modules/html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -13455,39 +13231,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -14389,13 +14132,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/is-symbol": {
 			"version": "1.0.4",
@@ -17234,25 +16970,11 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
-		"node_modules/lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"node_modules/lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/lodash.isarguments": {
 			"version": "3.1.0",
@@ -17265,13 +16987,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
 			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
 			"dev": true
-		},
-		"node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/lodash.ismatch": {
 			"version": "4.4.0",
@@ -18060,13 +17775,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -18137,36 +17845,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
-		},
-		"node_modules/nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"bin": {
-				"nearley-railroad": "bin/nearley-railroad.js",
-				"nearley-test": "bin/nearley-test.js",
-				"nearley-unparse": "bin/nearley-unparse.js",
-				"nearleyc": "bin/nearleyc.js"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://nearley.js.org/#give-to-nearley"
-			}
-		},
-		"node_modules/nearley/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -21998,19 +21676,6 @@
 			"inBundle": true,
 			"license": "ISC"
 		},
-		"node_modules/nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/nth-check?sponsor=1"
-			}
-		},
 		"node_modules/nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -22511,46 +22176,6 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
 			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
 			"dev": true
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
 		},
 		"node_modules/pascal-case": {
 			"version": "3.1.2",
@@ -24733,27 +24358,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"node_modules/railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -25375,9 +24979,9 @@
 			}
 		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.10",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-			"integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
 			"dev": true
 		},
 		"node_modules/regenerator-transform": {
@@ -25849,17 +25453,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
 			}
 		},
 		"node_modules/rsvp": {
@@ -28888,20 +28481,6 @@
 				}
 			}
 		},
-		"node_modules/terser-webpack-plugin/node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/terser-webpack-plugin/node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -31927,6 +31506,14 @@
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.10"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.11",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+					"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -31937,6 +31524,14 @@
 			"requires": {
 				"core-js-pure": "^3.20.2",
 				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.11",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+					"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/template": {
@@ -32298,8 +31893,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.1.tgz",
 			"integrity": "sha512-xrvsmVUtefWMWQsGgFffqWSK03pZ1vfDki4IVIIUxxDKnGBzqNgv0A7SB1oXtVNEkcVO8xi1ZrTL29HhSu5kGA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/css-tokenizer": {
 			"version": "2.2.0",
@@ -32311,15 +31905,13 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.4.tgz",
 			"integrity": "sha512-V/OUXYX91tAC1CDsiY+HotIcJR+vPtzrX8pCplCpT++i8ThZZsq5F5dzZh/bDM3WUOjrvC1ljed1oSJxMfjqhw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/selector-specificity": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
 			"integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.6",
@@ -32493,8 +32085,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
 			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@emotion/utils": {
 			"version": "1.0.0",
@@ -33140,8 +32731,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "6.7.0",
@@ -34285,8 +33875,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
 			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.0",
@@ -34301,8 +33890,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
 			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.6",
@@ -34365,8 +33953,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz",
 			"integrity": "sha512-518mL3goaSeXtJCQcPK9OYHUUiA0sjXuoGWHBwRalkyTIQZZy5ZZzlwrlSc9ESZcOw9BZ+Uo8CJRjV2OWnx+Zw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.5.0",
@@ -36388,8 +35975,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -36457,8 +36043,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -36623,20 +36208,6 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
-		},
-		"array.prototype.filter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
-			"integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"es-abstract": "^1.22.1",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			}
 		},
 		"array.prototype.find": {
 			"version": "2.2.1",
@@ -37332,56 +36903,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"dependencies": {
-				"entities": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-					"dev": true,
-					"peer": true
-				},
-				"parse5": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-					"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
-		"cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			}
 		},
 		"chokidar": {
 			"version": "3.5.3",
@@ -38174,8 +37695,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
 			"integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"create-require": {
 			"version": "1.1.1",
@@ -38353,20 +37873,6 @@
 				}
 			}
 		},
-		"css-select": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.1.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"nth-check": "^2.0.1"
-			}
-		},
 		"css-select-base-adapter": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
@@ -38390,13 +37896,6 @@
 					"dev": true
 				}
 			}
-		},
-		"css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"dev": true,
-			"peer": true
 		},
 		"css.escape": {
 			"version": "1.5.1",
@@ -39016,13 +38515,6 @@
 			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
 			"dev": true
 		},
-		"discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -39053,27 +38545,6 @@
 			"integrity": "sha512-LwNVg3GJOprWDO+QhLL1Z9MMgWe/KAFLxVWKzjRTxNSPn8/LLDIfmuG71YHznXCqaqTjvHJDYO1MEAgX6XCNbQ==",
 			"dev": true
 		},
-		"dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"dependencies": {
-				"entities": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-					"dev": true,
-					"peer": true
-				}
-			}
-		},
 		"domelementtype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -39095,28 +38566,6 @@
 					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
 					"dev": true
 				}
-			}
-		},
-		"domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0"
-			}
-		},
-		"domutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3"
 			}
 		},
 		"dot-case": {
@@ -39330,37 +38779,6 @@
 			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
 			"dev": true
 		},
-		"enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			}
-		},
 		"enzyme-matchers": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-7.1.2.tgz",
@@ -39470,13 +38888,6 @@
 				"unbox-primitive": "^1.0.2",
 				"which-typed-array": "^1.1.13"
 			}
-		},
-		"es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
 		},
 		"es-module-lexer": {
 			"version": "0.9.3",
@@ -39652,8 +39063,7 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
 			"integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -41060,17 +40470,6 @@
 			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
-		"html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			}
-		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -41091,28 +40490,6 @@
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"entities": "^4.4.0"
-			},
-			"dependencies": {
-				"entities": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
@@ -41165,8 +40542,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
 			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ignore": {
 			"version": "4.0.6",
@@ -41778,13 +41154,6 @@
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
-		},
-		"is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-			"dev": true,
-			"peer": true
 		},
 		"is-symbol": {
 			"version": "1.0.4",
@@ -43215,8 +42584,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "27.4.0",
@@ -44009,25 +43377,11 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
-		"lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -44040,13 +43394,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
 			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
 			"dev": true
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true,
-			"peer": true
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -44628,13 +43975,6 @@
 				"moment": ">= 2.9.0"
 			}
 		},
-		"moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -44690,28 +44030,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
-		},
-		"nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -45273,8 +44591,7 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
 					"integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"eslint-utils": {
 					"version": "3.0.0",
@@ -47453,16 +46770,6 @@
 				"path-key": "^3.0.0"
 			}
 		},
-		"nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0"
-			}
-		},
 		"nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -47825,36 +47132,6 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
 			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
 			"dev": true
-		},
-		"parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"dependencies": {
-				"entities": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-					"dev": true,
-					"peer": true
-				},
-				"parse5": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-					"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
 		},
 		"pascal-case": {
 			"version": "3.1.2",
@@ -48666,8 +47943,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
 			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -49190,15 +48466,13 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
 			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-scss": {
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
 			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.13",
@@ -49501,24 +48775,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			}
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -49552,8 +48808,7 @@
 			"version": "6.9.9",
 			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
 			"integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"react": {
 			"version": "17.0.2",
@@ -49580,8 +48835,7 @@
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
 			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"react-dates": {
 			"version": "21.8.0",
@@ -49891,8 +49145,7 @@
 			"version": "0.15.2",
 			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
 			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"reakit-warning": {
 			"version": "0.6.2",
@@ -50011,9 +49264,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.10",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-			"integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
 			"dev": true
 		},
 		"regenerator-transform": {
@@ -50371,17 +49624,6 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
-			}
-		},
-		"rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
 			}
 		},
 		"rsvp": {
@@ -52075,8 +51317,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
 					"integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"argparse": {
 					"version": "2.0.1",
@@ -52348,8 +51589,7 @@
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
 			"integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-standard": {
 			"version": "30.0.1",
@@ -52726,14 +51966,6 @@
 				"terser": "^5.7.2"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "8.11.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-					"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-					"dev": true,
-					"optional": true,
-					"peer": true
-				},
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -53425,8 +52657,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
 			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"use-lilius": {
 			"version": "2.0.3",
@@ -53441,15 +52672,13 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
 			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"use-sync-external-store": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
 			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -53636,8 +52865,7 @@
 					"version": "1.8.0",
 					"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 					"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"schema-utils": {
 					"version": "3.1.1",
@@ -53868,8 +53096,7 @@
 			"version": "7.5.6",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
 			"integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"newspack-scripts": "^5.5.0",
 		"postcss-scss": "^4.0.9",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
+		"regenerator-runtime": "^0.14.1",
 		"stylelint": "^15.11.0"
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,12 +12,12 @@ const path = require( 'path' );
 /**
  * Internal variables
  */
-const editor = path.join( __dirname, 'src', 'editor' );
+const entry = [ 'regenerator-runtime/runtime', path.join( __dirname, 'src', 'editor' ) ];
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry: { editor },
+		entry,
 		'output-path': path.join( __dirname, 'dist' ),
 	}
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WP 6.6 changes some things and `regenerator-runtime` is not available anymore. This PR adds it to every entry file processed by webpack. 

### How to test the changes in this Pull Request:

No functional changes—all should work as expected.

\* `6.6-beta2` to be exact

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->