### PR TITLE
fix: update newspack-scripts to v5.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@rushstack/eslint-patch": "^1.10.3",
 				"eslint": "^7.32.0",
 				"lint-staged": "^15.2.7",
-				"newspack-scripts": "^5.5.0",
+				"newspack-scripts": "^5.5.1",
 				"postcss-scss": "^4.0.9",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 				"regenerator-runtime": "^0.14.1",
@@ -17859,9 +17859,9 @@
 			"dev": true
 		},
 		"node_modules/newspack-scripts": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.0.tgz",
-			"integrity": "sha512-LyRrx8omcdXR1RuU9OpcsNoWw8GmPNdYxfjFBBbC4s7KDHPRptt5m+3RCzzDjyu2on64yuTK4m1lHlwnSog4Rw==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.1.tgz",
+			"integrity": "sha512-0M6P1XNpHJ7tRVD3hLpOK8rFEzDzB93EkGweA7Q+HOb4ke+ZjoUmqDl0aBMesvtPA019KsYExIiOWlzs4S6kNg==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -31893,7 +31893,8 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.1.tgz",
 			"integrity": "sha512-xrvsmVUtefWMWQsGgFffqWSK03pZ1vfDki4IVIIUxxDKnGBzqNgv0A7SB1oXtVNEkcVO8xi1ZrTL29HhSu5kGA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@csstools/css-tokenizer": {
 			"version": "2.2.0",
@@ -31905,13 +31906,15 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.4.tgz",
 			"integrity": "sha512-V/OUXYX91tAC1CDsiY+HotIcJR+vPtzrX8pCplCpT++i8ThZZsq5F5dzZh/bDM3WUOjrvC1ljed1oSJxMfjqhw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@csstools/selector-specificity": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
 			"integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.6",
@@ -32085,7 +32088,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
 			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@emotion/utils": {
 			"version": "1.0.0",
@@ -32731,7 +32735,8 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "6.7.0",
@@ -33875,7 +33880,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
 			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.0",
@@ -33890,7 +33896,8 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
 			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.6",
@@ -33953,7 +33960,8 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz",
 			"integrity": "sha512-518mL3goaSeXtJCQcPK9OYHUUiA0sjXuoGWHBwRalkyTIQZZy5ZZzlwrlSc9ESZcOw9BZ+Uo8CJRjV2OWnx+Zw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.5.0",
@@ -35975,7 +35983,8 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -36043,7 +36052,8 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -37695,7 +37705,8 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
 			"integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"create-require": {
 			"version": "1.1.1",
@@ -39063,7 +39074,8 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
 			"integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -40542,7 +40554,8 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
 			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"ignore": {
 			"version": "4.0.6",
@@ -42584,7 +42597,8 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"jest-regex-util": {
 			"version": "27.4.0",
@@ -44044,9 +44058,9 @@
 			"dev": true
 		},
 		"newspack-scripts": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.0.tgz",
-			"integrity": "sha512-LyRrx8omcdXR1RuU9OpcsNoWw8GmPNdYxfjFBBbC4s7KDHPRptt5m+3RCzzDjyu2on64yuTK4m1lHlwnSog4Rw==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.1.tgz",
+			"integrity": "sha512-0M6P1XNpHJ7tRVD3hLpOK8rFEzDzB93EkGweA7Q+HOb4ke+ZjoUmqDl0aBMesvtPA019KsYExIiOWlzs4S6kNg==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -44591,7 +44605,8 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
 					"integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				},
 				"eslint-utils": {
 					"version": "3.0.0",
@@ -47943,7 +47958,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
 			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -48466,13 +48482,15 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
 			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-scss": {
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
 			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.13",
@@ -48808,7 +48826,8 @@
 			"version": "6.9.9",
 			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
 			"integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"react": {
 			"version": "17.0.2",
@@ -48835,7 +48854,8 @@
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
 			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"react-dates": {
 			"version": "21.8.0",
@@ -49145,7 +49165,8 @@
 			"version": "0.15.2",
 			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
 			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"reakit-warning": {
 			"version": "0.6.2",
@@ -51317,7 +51338,8 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
 					"integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				},
 				"argparse": {
 					"version": "2.0.1",
@@ -51589,7 +51611,8 @@
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
 			"integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"stylelint-config-standard": {
 			"version": "30.0.1",
@@ -52657,7 +52680,8 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
 			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"use-lilius": {
 			"version": "2.0.3",
@@ -52672,13 +52696,15 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
 			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"use-sync-external-store": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
 			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -52865,7 +52891,8 @@
 					"version": "1.8.0",
 					"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 					"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				},
 				"schema-utils": {
 					"version": "3.1.1",
@@ -53096,7 +53123,8 @@
 			"version": "7.5.6",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
 			"integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@rushstack/eslint-patch": "^1.10.3",
 		"eslint": "^7.32.0",
 		"lint-staged": "^15.2.7",
-		"newspack-scripts": "^5.5.0",
+		"newspack-scripts": "^5.5.1",
 		"postcss-scss": "^4.0.9",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 		"regenerator-runtime": "^0.14.1",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps the `newspack-scripts` to 5.5.1, which [fixes an issue with generating alpha releases](https://github.com/Automattic/newspack-scripts/pull/212).

### How to test the changes in this Pull Request:

1. Confirm that `npm run build` looks okay! 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
