### PR TITLE
fix: specify asset filenames as editor.*

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,12 +12,14 @@ const path = require( 'path' );
 /**
  * Internal variables
  */
-const entry = [ 'regenerator-runtime/runtime', path.join( __dirname, 'src', 'editor' ) ];
+const editor = [ 'regenerator-runtime/runtime', path.join( __dirname, 'src', 'editor' ) ];
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry,
+		entry: {
+			editor,
+		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue introduced in #305.

### How to test the changes in this Pull Request:

1. On `release`, run `rm -r dist && npm run build`. Observe that built assets are outputted as `main.js`, `main.css`, and `main.asset.php`. Also observe that when editing a Sponsor in WP admin, the assets are not found because they're enqueued as `editor.*`.
2. On this branch, run the same command and confirm that they're outputted as `editor.*` and that the files enqueue correctly in WP admin.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
