### PR TITLE
ci: update dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,8 +17,46 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Check for major version bumps in PR body
+        if: steps.metadata.outputs.update-type == ''
+        id: check-major
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Parse "from X to Y" version pairs from the PR body and flag major bumps.
+          HAS_MAJOR=false
+          while IFS= read -r line; do
+            from_ver=$(echo "$line" | sed -n 's/.*from \([0-9][0-9.]*\) to \([0-9][0-9.]*\).*/\1/p')
+            to_ver=$(echo "$line" | sed -n 's/.*from \([0-9][0-9.]*\) to \([0-9][0-9.]*\).*/\2/p')
+            [ -z "$from_ver" ] && continue
+            from_major="${from_ver%%.*}"
+            to_major="${to_ver%%.*}"
+            if [ "$from_major" != "$to_major" ]; then
+              echo "Major bump detected: $from_ver -> $to_ver"
+              HAS_MAJOR=true
+            fi
+          done <<< "$PR_BODY"
+          echo "has_major=$HAS_MAJOR" >> "$GITHUB_OUTPUT"
+
+      - name: Approve PR
+        if: >-
+          ((contains(steps.metadata.outputs.update-type, 'version-update:semver-minor') ||
+          contains(steps.metadata.outputs.update-type, 'version-update:semver-patch')) &&
+          !contains(steps.metadata.outputs.update-type, 'version-update:semver-major')) ||
+          (steps.metadata.outputs.update-type == '' &&
+          steps.check-major.outputs.has_major != 'true')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+
       - name: Enable auto-merge for minor and patch updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: >-
+          ((contains(steps.metadata.outputs.update-type, 'version-update:semver-minor') ||
+          contains(steps.metadata.outputs.update-type, 'version-update:semver-patch')) &&
+          !contains(steps.metadata.outputs.update-type, 'version-update:semver-major')) ||
+          (steps.metadata.outputs.update-type == '' &&
+          steps.check-major.outputs.has_major != 'true')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

- Replace deprecated `ahmadnassri/action-dependabot-auto-merge@v2` + `actions/checkout@v2` with the official `dependabot/fetch-metadata@v2` approach
- Aligns with the workflow already in use across other Newspack repos
- Includes support for grouped (multi-dependency) Dependabot PRs while rejecting major version bumps

## Test plan

- [ ] Verify the workflow triggers correctly on the next Dependabot PR
- [ ] Verify grouped Dependabot PRs are auto-approved
- [ ] Verify major version bumps are NOT auto-approved