### PR TITLE
chore: import PluginDocumentSettingPanel from @wordpress/editor

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`PluginDocumentSettingPanel` was relocated from `@wordpress/edit-post` to `@wordpress/editor` in WP 6.6. The `edit-post` re-export still works today but emits a deprecation warning and is a candidate for removal in a future release.

The Sponsor Settings sidebar (visible on the sponsor CPT only) is unchanged in appearance and behavior.

### How to test the changes in this Pull Request:

1. Make sure your site is on 7.0 RC2
2. On a site running this branch, edit a sponsor (`newspack_spnsrs_cpt`) post.
3. Open the document settings sidebar — confirm the **Sponsor Settings** panel renders, including the byline, flag, disclaimer, sponsorship scope, native byline/category display overrides, and underwriter style/placement controls.
4. Adjust each control, save the post, reload, and verify values persist on the post.
5. Edit a regular post or page — confirm the Sponsor display-override controls still appear inside the Sponsors taxonomy panel via the `editor.PostTaxonomyType` filter (this code path was not touched but should be verified for regressions).
6. Open the browser console while editing a sponsor post — confirm no React errors and no deprecation warnings about `PluginDocumentSettingPanel`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?